### PR TITLE
fix dependency injection

### DIFF
--- a/dist/featureFlags.js
+++ b/dist/featureFlags.js
@@ -6,7 +6,7 @@
 
 (function(){
 angular.module('feature-flags', []);
-angular.module('feature-flags').directive('featureFlag', function(featureFlags) {
+angular.module('feature-flags').directive('featureFlag', ['featureFlags', function(featureFlags) {
     return {
         transclude: 'element',
         priority: 600,
@@ -45,8 +45,9 @@ angular.module('feature-flags').directive('featureFlag', function(featureFlags) 
             };
         }
     };
-});
-angular.module('feature-flags').directive('featureFlagOverrides', function(featureFlags) {
+}]);
+
+angular.module('feature-flags').directive('featureFlagOverrides', ['featureFlags', function(featureFlags) {
     return {
         restrict: 'A',
         link: function postLink($scope) {
@@ -70,8 +71,9 @@ angular.module('feature-flags').directive('featureFlagOverrides', function(featu
                   '</div>',
         replace: true
     };
-});
-angular.module('feature-flags').service('featureFlagOverrides', function($rootElement) {
+}]);
+
+angular.module('feature-flags').service('featureFlagOverrides', ['$rootElement', function($rootElement) {
     var appName = $rootElement.attr('ng-app'),
         keyPrefix = 'featureFlags.' + appName + '.',
 
@@ -116,8 +118,9 @@ angular.module('feature-flags').service('featureFlagOverrides', function($rootEl
             }
         }
     };
-});
-angular.module('feature-flags').service('featureFlags', function($q, featureFlagOverrides) {
+}]);
+
+angular.module('feature-flags').service('featureFlags', ['$q', 'featureFlagOverrides', function($q, featureFlagOverrides) {
         var serverFlagCache = {},
             flags = [],
 
@@ -183,5 +186,6 @@ angular.module('feature-flags').service('featureFlags', function($q, featureFlag
             isOn: isOn,
             isOverridden: isOverridden
         };
-    });
+    }]);
+
 }());

--- a/src/featureFlag.directive.js
+++ b/src/featureFlag.directive.js
@@ -1,4 +1,4 @@
-angular.module('feature-flags').directive('featureFlag', function(featureFlags) {
+angular.module('feature-flags').directive('featureFlag', ['featureFlags', function(featureFlags) {
     return {
         transclude: 'element',
         priority: 600,
@@ -37,4 +37,4 @@ angular.module('feature-flags').directive('featureFlag', function(featureFlags) 
             };
         }
     };
-});
+}]);

--- a/src/featureFlagOverrides.directive.js
+++ b/src/featureFlagOverrides.directive.js
@@ -1,4 +1,4 @@
-angular.module('feature-flags').directive('featureFlagOverrides', function(featureFlags) {
+angular.module('feature-flags').directive('featureFlagOverrides', ['featureFlags', function(featureFlags) {
     return {
         restrict: 'A',
         link: function postLink($scope) {
@@ -22,4 +22,4 @@ angular.module('feature-flags').directive('featureFlagOverrides', function(featu
                   '</div>',
         replace: true
     };
-});
+}]);

--- a/src/featureFlagOverrides.service.js
+++ b/src/featureFlagOverrides.service.js
@@ -1,4 +1,4 @@
-angular.module('feature-flags').service('featureFlagOverrides', function($rootElement) {
+angular.module('feature-flags').service('featureFlagOverrides', ['$rootElement', function($rootElement) {
     var appName = $rootElement.attr('ng-app'),
         keyPrefix = 'featureFlags.' + appName + '.',
 
@@ -43,4 +43,4 @@ angular.module('feature-flags').service('featureFlagOverrides', function($rootEl
             }
         }
     };
-});
+}]);

--- a/src/featureFlags.service.js
+++ b/src/featureFlags.service.js
@@ -1,4 +1,4 @@
-angular.module('feature-flags').service('featureFlags', function($q, featureFlagOverrides) {
+angular.module('feature-flags').service('featureFlags', ['$q', 'featureFlagOverrides', function($q, featureFlagOverrides) {
         var serverFlagCache = {},
             flags = [],
 
@@ -64,4 +64,4 @@ angular.module('feature-flags').service('featureFlags', function($q, featureFlag
             isOn: isOn,
             isOverridden: isOverridden
         };
-    });
+    }]);


### PR DESCRIPTION
> As a developer, I want to be able to use _featureFlags.js_ in my app. When deploying, I want to be able to compile it without error.

This change fixes an `Unknown provider: eProvider <- e <- featureFlags` error that you will run into otherwise.
