### PR TITLE
Bower main file should point only to uncompressed js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,6 @@
     "!README.md"
   ],
   "main": [
-    "dist/**/*"
+    "dist/featureFlags.js"
   ]
 }


### PR DESCRIPTION
Main shouldn't point to both the compressed and uncompressed JS files, as plugins that programmatically grab these files (like https://github.com/ck86/main-bower-files) will then double include your library.