### PR TITLE
Add IDs to featureFlagOverrides directive

### DIFF
--- a/src/featureFlagOverrides.directive.js
+++ b/src/featureFlagOverrides.directive.js
@@ -13,11 +13,11 @@ angular.module('feature-flags').directive('featureFlagOverrides', function(featu
         },
         template: '<div class="feature-flags">' +
                   '    <h1>Feature Flags</h1>' +
-                  '    <div class="feature-flags-flag" ng-repeat="flag in flags">' +
+                  '    <div id="feature-flag--{{flag.key}}" class="feature-flags-flag" ng-repeat="flag in flags">' +
                   '        <div class="feature-flags-name">{{flag.name || flag.key}}</div>' +
-                  '        <div class="feature-flags-switch" ng-click="enable(flag)" ng-class="{\'active\': isOverridden(flag.key) && isOn(flag.key)}">ON</div>' +
-                  '        <div class="feature-flags-switch" ng-click="disable(flag)" ng-class="{\'active\': isOverridden(flag.key) && !isOn(flag.key)}">OFF</div>' +
-                  '        <div class="feature-flags-switch" ng-click="reset(flag)" ng-class="{\'active\': !isOverridden(flag.key)}">DEFAULT ({{isOnByDefault(flag.key) ? \'ON\' : \'OFF\'}})</div>' +
+                  '        <div id="feature-flag--{{flag.key}}--enable" class="feature-flags-switch" ng-click="enable(flag)" ng-class="{\'active\': isOverridden(flag.key) && isOn(flag.key)}">ON</div>' +
+                  '        <div id="feature-flag--{{flag.key}}--disable" class="feature-flags-switch" ng-click="disable(flag)" ng-class="{\'active\': isOverridden(flag.key) && !isOn(flag.key)}">OFF</div>' +
+                  '        <div id="feature-flag--{{flag.key}}--reset" class="feature-flags-switch" ng-click="reset(flag)" ng-class="{\'active\': !isOverridden(flag.key)}">DEFAULT ({{isOnByDefault(flag.key) ? \'ON\' : \'OFF\'}})</div>' +
                   '        <div class="feature-flags-desc">{{flag.description}}</div>' +
                   '    </div>' +
                   '</div>',


### PR DESCRIPTION
At WHOOP, we find these IDs to be very helpful for enabling specific feature flags as part of the setup process for Selenium/Protractor test suites.