### PR TITLE
Gracefully handle unavailable localStorage

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,7 +81,7 @@ gulp.task('test', ['clean'], function() {
 gulp.task('clean', function() {
     return gulp.src('test/coverage')
         .pipe(clean());
-})
+});
 
 
 gulp.task('coveralls', ['test'], function() {

--- a/src/featureFlagOverrides.service.js
+++ b/src/featureFlagOverrides.service.js
@@ -2,6 +2,16 @@ angular.module('feature-flags').service('featureFlagOverrides', function($rootEl
     var appName = $rootElement.attr('ng-app'),
         keyPrefix = 'featureFlags.' + appName + '.',
 
+        localStorageAvailable = (function() {
+            try {
+                localStorage.setItem('featureFlags.availableTest', 'test');
+                localStorage.removeItem('featureFlags.availableTest');
+                return true;
+            } catch (e) {
+                return false;
+            }
+        }()),
+
         prefixedKeyFor = function(flagName) {
             return keyPrefix + flagName;
         },
@@ -11,15 +21,21 @@ angular.module('feature-flags').service('featureFlagOverrides', function($rootEl
         },
 
         set = function(value, flagName) {
-            localStorage.setItem(prefixedKeyFor(flagName), value);
+            if (localStorageAvailable) {
+                localStorage.setItem(prefixedKeyFor(flagName), value);
+            }
         },
 
         get = function(flagName) {
-            return localStorage.getItem(prefixedKeyFor(flagName));
+            if (localStorageAvailable) {
+                return localStorage.getItem(prefixedKeyFor(flagName));
+            }
         },
 
         remove = function(flagName) {
-            localStorage.removeItem(prefixedKeyFor(flagName));
+            if (localStorageAvailable) {
+                localStorage.removeItem(prefixedKeyFor(flagName));
+            }
         };
 
     return {
@@ -37,9 +53,11 @@ angular.module('feature-flags').service('featureFlagOverrides', function($rootEl
         remove: remove,
         reset: function() {
             var key;
-            for (key in localStorage) {
-                if (isPrefixedKey(key)) {
-                    localStorage.removeItem(key);
+            if (localStorageAvailable) {
+                for (key in localStorage) {
+                    if (isPrefixedKey(key)) {
+                        localStorage.removeItem(key);
+                    }
                 }
             }
         }

--- a/test/featureFlagOverrides.service.spec.js
+++ b/test/featureFlagOverrides.service.spec.js
@@ -64,7 +64,7 @@
         });
 
         describe('when I check the state of an override', function() {
-            describe('if there one', function() {
+            describe('if there is one', function() {
                 beforeEach(function() {
                     spyOn(localStorage, 'getItem').andReturn('true');
                 });
@@ -88,7 +88,7 @@
         describe('when I have a series of overrides and then clear them', function() {
             beforeEach(function() {
                 spyOn(localStorage, 'removeItem');
-                localStorage.setItem('someOtherData');
+                localStorage.setItem('someOtherData', true);
                 service.set('FLAG_KEY_1', 'VALUE');
                 service.set('FLAG_KEY_2', 'VALUE');
                 service.set('FLAG_KEY_3', 'VALUE');
@@ -107,6 +107,73 @@
 
             it('should not remove unrelated local storage items', function() {
                 expect(localStorage.removeItem).not.toHaveBeenCalledWith('someOtherData');
+            });
+        });
+    });
+
+    describe('Service: featureFlagOverrides when localStorage is not available', function() {
+        var service;
+
+        beforeEach(function() {
+            spyOn(localStorage, 'setItem').andThrow();
+            spyOn(localStorage, 'getItem').andThrow();
+            spyOn(localStorage, 'removeItem').andThrow();
+        });
+
+        beforeEach(module('feature-flags'));
+
+        beforeEach(inject(function(featureFlagOverrides) {
+            service = featureFlagOverrides;
+            localStorage.setItem.reset();
+        }));
+
+        describe('when I set an override', function() {
+            beforeEach(function() {
+                service.set('FLAG_KEY', 'VALUE');
+            });
+
+            it('do nothing', function() {
+                expect(localStorage.setItem).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when I set a hash of overrides', function() {
+            beforeEach(function() {
+                service.set({ 'FLAG_KEY_1': 'VALUE_1' });
+            });
+
+            it('do nothing', function() {
+                expect(localStorage.setItem).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when I get an override', function() {
+            beforeEach(function() {
+                service.get('FLAG_KEY');
+            });
+
+            it('should do nothing', function() {
+                expect(localStorage.getItem).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when I remove an override', function() {
+            beforeEach(function() {
+                service.remove('FLAG_KEY');
+            });
+
+            it('should do nothing', function() {
+                expect(localStorage.removeItem).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when I clear all overrides', function() {
+            beforeEach(function() {
+                service.reset();
+            });
+
+            it('should do nothing', function() {
+                expect(localStorage.removeItem).not.toHaveBeenCalled();
             });
         });
     });


### PR DESCRIPTION
This is essentially https://github.com/mjt01/angular-feature-flags/pull/32 (which has not been updated as requested) but with specs so the coverage doesn't decrease. 

It's slightly more concise and avoids adding a global variable for testing `localStorage` availability.