### PR TITLE
Feature toggles override check not working when localStorage is not available

### DIFF
--- a/src/featureFlagOverrides.service.js
+++ b/src/featureFlagOverrides.service.js
@@ -40,7 +40,8 @@ angular.module('feature-flags').service('featureFlagOverrides', function($rootEl
 
   return {
     isPresent: function(key) {
-      return get(key) !== null;
+      var value = get(key);
+      return typeof value !== 'undefined' && value !== null;
     },
     get: get,
     set: function(flag, value) {

--- a/test/featureFlagOverrides.service.spec.js
+++ b/test/featureFlagOverrides.service.spec.js
@@ -178,5 +178,11 @@
         expect(localStorage.removeItem).not.toHaveBeenCalled();
       });
     });
+
+    describe('when I check the state of an override', function() {
+      it('should return false', function() {
+        expect(service.isPresent('FLAG_KEY')).toBeFalsy();
+      });
+    });
   });
 }(window.angular));


### PR DESCRIPTION
When localStorage is not available featureOverrides.isPresent always returns true because featureOverrides.get always returns undefined and we are comparing undefined is not equal to null.