### PR TITLE
Export module name to make it possible to use package as CommonJS module

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-feature-flags",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "authors": [
     {
       "name": "Michael Taranto",

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require('./dist/featureFlags.js');
+module.exports = 'feature-flags';

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "angular-feature-flags",
   "title": "Angular Feature Flags",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Feature Flag module for Angular JS apps",
-  "main": "dist/featureFlags.js",
+  "main": "index.js",
   "keywords": [
     "angular",
     "feature flag",


### PR DESCRIPTION
Hi!

I'm using Browserify to bundle my app and other Angular modules can be imported as CommonJS modules. For example:

```
angular.module('myApp', [
        require('angular-ui-bootstrap'),
        require('angular-animate'),
        require('angular-touch')
]);
```

Angular-feature-flags is not so convenient, I have to do this:

```
require('angular-feature-flags');

angular.module('myApp', [
        'feature-flags'
]);
```

Should you have any question or remark, please do not hesitate to ask.